### PR TITLE
Mac OSX fixes for `sed` extended regular expressions and and `expr` parsing numbers with whitespace

### DIFF
--- a/parcimonie.sh
+++ b/parcimonie.sh
@@ -71,11 +71,18 @@ if [ -n "$gnupgKeyserverOptions" ]; then
 	gnupgExec+=(--keyserver-options "$gnupgKeyserverOptions")
 fi
 
-sedExtRegexp() {
+# Test for GNU `sed`, or use a `sed` fallback in sedExtRegexp
+sedExec=(sed)
+if echo "test the extended regexp flag" | sed -r &> /dev/null; then
 	# GNU Linux sed
-	#sed -r "$@"
+    sedExec+=(-r)
+else
 	# Mac OS (BSD?) sed
-	sed -E "$@"
+	sedExec+=(-E)
+fi
+
+sedExtRegexp() {
+	"${sedExec[@]}" "$@"
 }
 
 keepDigitsOnly() {


### PR DESCRIPTION
In reference to issue #1.
- The `sed` command is tested for the `-r` flag, and uses the `-E` flag as a fallback.
- Numbers from external commands are stripped from anything non-digit, before being passed into `expr`.

Tested on a non-pristine Mac OSX 10.9 Mavericks system, with enough non-system (GNU etcetera) software to possibly affect the actual Mac OSX portability of this script. Try it out!
