### PR TITLE
Fix getPublicKeys()

### DIFF
--- a/parcimonie.sh
+++ b/parcimonie.sh
@@ -126,7 +126,8 @@ cleanup() {
 getPublicKeys() {
 	nontor_gnupg --list-public-keys --with-colons --fixed-list-mode --with-fingerprint --with-fingerprint --with-key-data |
 		grep -A 1 '^pub:' |                          # only allow fingerprints of public keys (not subkeys)
-		grep -E   '^fpr:' |
+		grep -E   '^fpr:+[0-9a-fA-F]{40,}:' |        # only allow fingerprints of v4 pgp keys
+		                                             # (v3 fingerprints consist of 32 hex characters)
 		sedExtRegexp 's/^fpr:+([0-9a-fA-F]+):+$/\1/' # extract the fingerprint
 }
 


### PR DESCRIPTION
Currently, getPublicKeys() will return fingerprints of keys _and_ subkeys which means keys with many subkeys will be updated much more frequently than others. Why the original parcimonie decided to call gpg in such a weird way i don't know (they do filter `fpr:` lines that are not immediately preceded by a `pub:` line though). However, I have checked that the only keys missing if the call to gpg is changed as suggested are subkey fingerprints.

The second commit filters gpg v3 fingerprints (32 bytes). They cannot be updated via hkp and I don't think there is any legitimate use for them (I will remove the second commit from this PR if you disagree, of course).
