### PR TITLE
Make sure random numbers are greater than zero.

### DIFF
--- a/parcimonie.sh
+++ b/parcimonie.sh
@@ -140,11 +140,15 @@ getNumKeys() {
 }
 
 getRandomKey() {
-	local allPublicKeys fingerprint
+	local allPublicKeys fingerprint randomChoice
 	allPublicKeys=()
 	for fingerprint in $(getPublicKeys); do
 		allPublicKeys+=("$fingerprint")
 	done
+	randomChoice=$(expr "$(getRandom)" % "${#allPublicKeys[@]}")
+	if [ $randomChoice -lt 0 ]; then
+		randomChoice=$(expr "$randomChoice" "*" "-1")
+	fi
 	echo "${allPublicKeys[$(expr "$(getRandom)" % "${#allPublicKeys[@]}")]}"
 }
 
@@ -155,11 +159,16 @@ getTimeToWait() {
 	# then we can encounter a modulo by zero. In this case, we use the following as fallback:
 	#   minimum wait time + rand(minimum wait time)
 	# = $minWaitTime + $(getRandom) % $minWaitTime
+        local waitTime
 	if [ "$(expr '2' '*' "$targetRefreshTime")" -le "$(getNumKeys)" ]; then
-		expr "$minWaitTime" '+' "$(getRandom)" '%' "$minWaitTime"
+		waitTime=$(expr "$minWaitTime" '+' "$(getRandom)" '%' "$minWaitTime")
 	else
-		expr "$minWaitTime" '+' "$(getRandom)" '%' '(' '2' '*' "$targetRefreshTime" '/' "$(getNumKeys)" ')'
+		waitTime=$(expr "$minWaitTime" '+' "$(getRandom)" '%' '(' '2' '*' "$targetRefreshTime" '/' "$(getNumKeys)" ')')
 	fi
+	if [ $waitTime -lt 0 ]; then
+		waitTime=$(expr "$waitTime" "*" "-1")
+	fi
+	echo $waitTime
 }
 
 if [ "$(getNumKeys)" -eq 0 ]; then


### PR DESCRIPTION
On my system, when sending random numbers from getRandom through the modulo operator the result sometimes is negative. This doesn't affect getRandomKey much since gpg won't try to get a key that is empty or doesn't exist, but the negative sign is seen as a switch in sleep, which errors out. This is probably due to a bug in expr, but this is a simple workaround for it.