### PR TITLE
Add the -a option to grep

### DIFF
--- a/parcimonie.sh
+++ b/parcimonie.sh
@@ -129,7 +129,7 @@ cleanup() {
 
 getPublicKeys() {
 	nontor_gnupg --list-public-keys --with-colons --fixed-list-mode --with-fingerprint --with-fingerprint --with-key-data |
-		grep -A 1 '^pub:' |                          # only allow fingerprints of public keys (not subkeys)
+		grep -a -A 1 '^pub:' |                       # only allow fingerprints of public keys (not subkeys)
 		grep -E   '^fpr:+[0-9a-fA-F]{40,}:' |        # only allow fingerprints of v4 pgp keys
 		                                             # (v3 fingerprints consist of 32 hex characters)
 		sedExtRegexp 's/^fpr:+([0-9a-fA-F]+):+$/\1/' # extract the fingerprint


### PR DESCRIPTION
I think this is related to issue #7: for some reason, grep consider the
output of `gpg --list-public-keys --fixed-list-mode --with-key-data` as
binary and skip outputing the matched lines.
By adding the -a we force grep to consider the input as text.