### PR TITLE
Create temp files using mktemp

### DIFF
--- a/parcimonie.sh
+++ b/parcimonie.sh
@@ -111,10 +111,10 @@ nontor_gnupg() {
 tor_gnupg() {
 	local torsocksConfig returnCode
 	umask 077
-    # Create tmp dir
-    mkdir -p $tmpPrefix
-    # Create tmp file
-    torsocksConfig="$(mktemp -p ${tmpPrefix} torsocks-XXXX.conf)"
+	# Create tmp dir
+	mkdir -p "$tmpPrefix"
+	# Create tmp file
+	torsocksConfig="$(mktemp -p $tmpPrefix torsocks-XXXX.conf)"
 	chmod 600 "$torsocksConfig"
 	echo "TorAddress $torAddress" > "$torsocksConfig"
 	echo "TorPort $torPort" >> "$torsocksConfig"

--- a/parcimonie.sh
+++ b/parcimonie.sh
@@ -110,9 +110,11 @@ nontor_gnupg() {
 
 tor_gnupg() {
 	local torsocksConfig returnCode
-	torsocksConfig="${tmpPrefix}-torsocks-$(getRandom).conf"
 	umask 077
-	touch "$torsocksConfig"
+    # Create tmp dir
+    mkdir -p $tmpPrefix
+    # Create tmp file
+    torsocksConfig="$(mktemp -p ${tmpPrefix} torsocks-XXXX.conf)"
 	chmod 600 "$torsocksConfig"
 	echo "TorAddress $torAddress" > "$torsocksConfig"
 	echo "TorPort $torPort" >> "$torsocksConfig"

--- a/parcimonie.sh
+++ b/parcimonie.sh
@@ -114,7 +114,7 @@ tor_gnupg() {
 	# Create tmp dir
 	mkdir -p "$tmpPrefix"
 	# Create tmp file
-	torsocksConfig="$(mktemp -p $tmpPrefix torsocks-XXXX.conf)"
+	torsocksConfig="$(mktemp -p "$tmpPrefix" torsocks-XXXX.conf)"
 	chmod 600 "$torsocksConfig"
 	echo "TorAddress $torAddress" > "$torsocksConfig"
 	echo "TorPort $torPort" >> "$torsocksConfig"


### PR DESCRIPTION
Using `mktemp` to create temporary files (e.g. the torsocks configuration file) will prevent collisions with existing files. Even if it is most unlikely to happen, it could happen in your code. `mktemp` simply won't create the file, if another file with the same name already exists