### PR TITLE
Use getent instead of reading /etc/passwd to list users

### DIFF
--- a/parcimonie.sh
+++ b/parcimonie.sh
@@ -34,7 +34,7 @@ if [ "$(whoami)" != "$parcimonieUser" ]; then
 			exit 1
 		fi
 		gnupgUsers=()
-		for user in $(cut -d ':' -f 1 < /etc/passwd); do
+		for user in $(getent passwd | cut -d ':' -f 1); do
 			if [ -d "$(eval "echo ~$user")/.gnupg" ]; then
 				gnupgUsers+=("$user")
 			fi


### PR DESCRIPTION
The passwd database may have other sources than /etc/passwd, e.g., IPA.
Using getent allows to use all these sources transparently.